### PR TITLE
ppcor is required as well for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ library(pacman)
 
 pacman::p_load(phyloseq, metacoder, pryr, biomformat, RColorBrewer, ggplot2, gplots, Cairo, igraph, 
 BiocParallel, randomForest, metagenomeSeq, MASS, DESeq2, vegan, RJSONIO, ggfortify, pheatmap, xtable, genefilter,
-data.table, reshape, stringr, ape, Tax4Fun, grid, gridExtra, splitstackshape, edgeR, globaltest, R.utils, viridis, ggrepel)
+data.table, reshape, stringr, ape, Tax4Fun, grid, gridExtra, splitstackshape, edgeR, globaltest, R.utils, viridis, ggrepel,
+ppcor)
 ```
 ### Step 2. Install the package 
 


### PR DESCRIPTION
Hi!

I got an error while trying to install MicrobiomeAnalystR:

```
Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : 
  there is no package called ‘ppcor’
Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
Execution halted
ERROR: lazy loading failed for package ‘MicrobiomeAnalystR’
* removing ‘/home/bela/.R/x86_64-pc-linux-gnu-library/3.6/MicrobiomeAnalystR’
Error: Failed to install 'MicrobiomeAnalystR' from GitHub:
  (converted from warning) installation of package ‘/tmp/RtmpWLKIrB/file24e8143395c6/MicrobiomeAnalystR_0.0.0.9000.tar.gz’ had non-zero exit status
```

Fixed by installing `ppcor`.

Thanks,
Bela